### PR TITLE
Select only the first child when there are more than one matched element to prevent show duplicate popovers

### DIFF
--- a/src/coffee/bootstrap-tour.coffee
+++ b/src/coffee/bootstrap-tour.coffee
@@ -491,7 +491,7 @@
         step.element = 'body'
         step.placement = 'top'
 
-      $element = $ step.element
+      $element = $ step.element + ':first'
       $element.addClass "tour-#{@_options.name}-element tour-#{@_options.name}-#{i}-element"
 
       $.extend options, step.options if step.options


### PR DESCRIPTION
Prevent showing duplicate popovers with the same selector

Fix https://github.com/galaxyproject/galaxy/issues/13079